### PR TITLE
use className instead of key alias to load associated models

### DIFF
--- a/Controller/ReportsController.php
+++ b/Controller/ReportsController.php
@@ -250,9 +250,12 @@ class ReportsController extends AppController {
             $associatedModelsSchema = array();
 
             foreach ($associatedModels as $key => $value) {
-                $this->loadModel($key);
-                $associatedModelsSchema[$key] = $this->{$key}->schema();
-                
+                $className = $this->{$modelClass}->{$value}[$key]['className'];
+                //$this->loadModel($key);
+                $this->loadModel($className);
+                //$associatedModelsSchema[$key] = $this->{$key}->schema();
+                $associatedModelsSchema[$key] = $this->{$className}->schema();
+
                 if (isset($globalFieldIgnoreList) && is_array($globalFieldIgnoreList)) {
                     foreach ($globalFieldIgnoreList as $value) {
                         unset($associatedModelsSchema[$key][$value]);
@@ -347,9 +350,11 @@ class ReportsController extends AppController {
                                     }
 
                                     if ($parameters['Filter']=='LIKE')
-                                        $example = '%'. mysql_real_escape_string($parameters['Example']) . '%';
+                                        //$example = '%'. mysql_real_escape_string($parameters['Example']) . '%';
+                                        $example = '%'.$parameters['Example'] . '%';
                                     else
-                                        $example = mysql_real_escape_string($parameters['Example']);
+                                        //$example = mysql_real_escape_string($parameters['Example']);
+                                        $example = $parameters['Example'];
 
                                     $conditionsList[$model.'.'.$field.$criteria] = $example;
                                 }


### PR DESCRIPTION
currently, if you use an alias (association key) that is different from the model name, it does not work, because it is using the key to load the data from the associated model, instead of using the className

this fixes the issue of using an association with an alias
that is different than the className

the plug-in will load the associated model correctly by using the
className instead of the defined alias in the key of the association
